### PR TITLE
Fix app lifecycle so that Control + C properly kills the backend server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ npm start -- /path/to/your/repo
 
 Once started, the application will be accessible in your web browser at `http://localhost:3000`.
 
+If you don't want the browser to open automatically (for example, when running in CI
+or when you prefer to open a browser manually), set the `NO_BROWSER` environment
+variable to `true` when starting:
+
+```bash
+NO_BROWSER=true npm start
+```
+
 ## Usage
 
 1.  Start the application using one of the methods above.
@@ -59,6 +67,10 @@ Once started, the application will be accessible in your web browser at `http://
 5.  The file tree will display all tracked files in your repository. Select the files you wish to compare by checking the boxes next to their names.
 6.  Click the "Generate Summary" button.
 7.  The application will display the diffs for the selected files, with additions highlighted in green and deletions in red.
+
+Stopping the server: use Ctrl+C in the terminal where `npm start` is running. The server
+now handles SIGINT/SIGTERM and will perform a graceful shutdown of the HTTP server
+so you won't leave orphaned processes running after closing the browser.
 
 ## Development
 

--- a/tests/integration/server.shutdown.test.ts
+++ b/tests/integration/server.shutdown.test.ts
@@ -1,0 +1,48 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+describe("Server shutdown behavior", () => {
+  it("should exit when receiving SIGINT", async () => {
+    const repoPath = path.join(__dirname, "../..");
+
+    // Spawn the built server from dist/ (pretest will have built this)
+    const child = spawn("node", ["dist/server.js"], {
+      cwd: repoPath,
+      env: { ...process.env, PORT: "0" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    // Wait for the server to advertise it's running
+    await new Promise<void>((resolve, reject) => {
+      const onData = (chunk: Buffer) => {
+        const text = chunk.toString();
+        if (text.includes("Server is running on")) {
+          resolve();
+        }
+      };
+
+      const onError = (err: Error) => reject(err);
+
+      child.stdout?.on("data", onData);
+      child.stderr?.on("data", onData);
+      child.on("error", onError);
+
+      // Safety timeout
+      setTimeout(
+        () => reject(new Error("Server failed to start in time")),
+        5000,
+      );
+    });
+
+    // Send SIGINT
+    child.kill("SIGINT");
+
+    // Wait for it to exit
+    const code = await new Promise<number | null>((resolve) => {
+      child.on("exit", (exitCode) => resolve(exitCode));
+      setTimeout(() => resolve(null), 5000);
+    });
+
+    expect(code).toBe(0);
+  }, 20000);
+});


### PR DESCRIPTION
# Pull Request

## Description
Fixes app lifecycle so that the backend server processes don't get orphaned after closing the browser window/tab. Currently, the backend process returns upon running `npm start` so you are unable to use a standard `CTRL` + `C` to kill the process. This keeps the process running in the terminal so that you can easily terminate it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (describe):

## Checklist
- [x] Tests added or updated (unit/integration/e2e as appropriate)
- [x] All tests pass locally (`npm run test:all`)
- [x] Linter passes (`npm run lint`)
- [x] Type check passes (`npm run type-check`)
- [x] Updated documentation (README / comments / CHANGELOG) if needed
- [x] Code follows project style (Biome) and conventions
- [x] Linked relevant issues / discussions